### PR TITLE
Improve tooling support

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,6 +37,12 @@ module.exports = function (config) {
       compilerOptions: {
         lib: ['ES2015', 'DOM']
       },
+      baseUrl: ".",
+      paths: {
+        "ngx-wig": [
+          "./dist/ngx-wig"
+        ]
+      },
       exclude: ["./playground"]
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,11 +21,6 @@ module.exports = function (config) {
       { pattern: 'src/**/*.html', included: true, watched: true },
     ],
 
-
-    // list of files to exclude
-    exclude: ["./playground"],
-
-
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
@@ -41,7 +36,8 @@ module.exports = function (config) {
       },
       compilerOptions: {
         lib: ['ES2015', 'DOM']
-      }
+      },
+      exclude: ["./playground"]
     },
 
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -19,6 +19,6 @@
   </head>
 
   <body>
-    <app>Loading AppComponent content here ...</app>
+    <my-app>Loading AppComponent content here ...</my-app>
   </body>
 </html>

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -10,7 +10,7 @@ import { NgxWigModule }  from 'ngx-wig';
 
 @Component({
   selector: 'my-app',
-  template: `<ngx-wig [isSourceModeAllowed]="true"></ngx-wig>`
+  template: `<ngx-wig [content]="text" [isSourceModeAllowed]="true"></ngx-wig>`
 })
 class AppComponent {}
 

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -9,7 +9,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { NgxWigModule }  from 'ngx-wig';
 
 @Component({
-  selector: 'app',
+  selector: 'my-app',
   template: `<ngx-wig [isSourceModeAllowed]="true"></ngx-wig>`
 })
 class AppComponent {}

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -9,6 +9,12 @@
     "experimentalDecorators": true,
     "lib": [ "es2015", "dom" ],
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "baseUrl": ".",
+    "paths": {
+      "ngx-wig": [
+        "../dist/ngx-wig"
+      ]
+    }
   }
 }

--- a/src/ngx-wig.component.spec.ts
+++ b/src/ngx-wig.component.spec.ts
@@ -150,6 +150,7 @@ class Page {
     this.execCommandSpy = spyOn(document, 'execCommand');
     this.promptSpy = spyOn(window, 'prompt');
     comp.content = '<p>Hello World</p>';
+    comp.isSourceModeAllowed = true;
   }
 
   addPageElements() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,11 @@
     "lib": ["es2015", "dom"],
     "skipLibCheck": true,
     "typeRoots": ["node_modules/@types"],
-    "types": ["jasmine", "node"]
+    "types": ["jasmine", "node"],
+    "paths": {
+      "ngx-wig": [
+        "../dist/ngx-wig"
+      ]
+    }
   }
 }


### PR DESCRIPTION
- Fix **Cannot find module 'ngx-wig'.** error in `playground/index.ts` when runnning `tsc` command.
- Fix **Cannot find module 'ngx-wig'.** error in `playground/index.ts` when opening the file in editor.
- Fix **Cannot find module 'ngx-wig'.** error in `playground/index.ts` when running karma.
- Rename the main component of the playground to pass **tslint** kebab case rule.
- Fix unit test for #50 