### PR TITLE
fix focus behavior

### DIFF
--- a/src/ngx-wig.html
+++ b/src/ngx-wig.html
@@ -8,7 +8,8 @@
                 [ngClass]="[button.styleClass, iconsTheme]"
                 [title]="button.title"
                 (click)="execCommand(button.command)"
-                [disabled]="disabled">
+                [disabled]="disabled"
+                tabindex="-1">
           {{ button.title }}
         </button>
       </div>
@@ -21,7 +22,8 @@
             [ngClass]="iconsTheme"
             *ngIf="isSourceModeAllowed"
             (click)="toggleEditMode()"
-            [disabled]="disabled">
+            [disabled]="disabled"
+            tabindex="-1">
       Edit HTML
     </button>
   </li>


### PR DESCRIPTION
This PR disables focusing of toolbar buttons.
This fixes focusing of ngx-wig when navigating with keyboard (tab key) from another input to ngx-wig. Previously toolbar buttons would be focused, but now content is focused and the user can start typing immediately.

This does prevent users from using the toolbar buttons with keyboard, but that can easily be fixed by implementing keyboard shortcuts