### PR TITLE
fix FormControl reset

### DIFF
--- a/src/ngx-wig.component.ts
+++ b/src/ngx-wig.component.ts
@@ -133,10 +133,10 @@ export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor 
   }
 
   public writeValue(value: any): void {
-    if (value) {
-      this.content = value;
-      this.container.innerHTML = this.content;
-    }
+    if (!value) { value = ''; }
+
+    this.container.innerHTML = value;
+    this._onContentChange(value);
   }
 
   public shouldShowPlaceholder(): boolean {


### PR DESCRIPTION
This PR allows the user to clear ngx-wig content by calling `reset('')` or `setValue('')` on a linked FormControl