### PR TITLE
apply styles in IE11

### DIFF
--- a/src/ngx-wig.component.ts
+++ b/src/ngx-wig.component.ts
@@ -73,7 +73,6 @@ export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor 
     if (this.editMode) {
       return false;
     }
-
     if (document.queryCommandSupported && !document.queryCommandSupported(command)) {
       throw 'The command "' + command + '" is not supported';
     }
@@ -83,6 +82,9 @@ export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor 
         return;
       }
     }
+
+    this.container.focus();
+
     // use insertHtml for `createlink` command to account for IE/Edge purposes, in case there is no selection
     let selection = document.getSelection().toString();
     if (command === 'createlink' && selection === '') {
@@ -92,7 +94,6 @@ export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor 
     }
 
     this._onContentChange(this.container.innerHTML);
-    this.container.focus();
   }
 
   public ngOnInit(): void {


### PR DESCRIPTION
There was a bag in IE11
STR:
- launch ngx-wig in IE11
- click 'Bold' button in toolbar
- type some text
Actual behavior: bold style doesn't apply to typed text (the same for others styles)
Expected behavior: bold style should apply to typed text right away 