### PR TITLE
Placeholder fix

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -10,7 +10,7 @@ import { NgxWigModule }  from 'ngx-wig';
 
 @Component({
   selector: 'my-app',
-  template: `<ngx-wig [content]="" [isSourceModeAllowed]="true" placeholder="yoyo"></ngx-wig>`
+  template: `<ngx-wig [content]="text" [isSourceModeAllowed]="true"></ngx-wig>`
 })
 class AppComponent {
   public text = `There are a few options for making a WYSIWYG editor that works in the browser.

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -10,7 +10,7 @@ import { NgxWigModule }  from 'ngx-wig';
 
 @Component({
   selector: 'my-app',
-  template: `<ngx-wig [content]="text" [isSourceModeAllowed]="true"></ngx-wig>`
+  template: `<ngx-wig [content]="" [isSourceModeAllowed]="true" placeholder="yoyo"></ngx-wig>`
 })
 class AppComponent {
   public text = `There are a few options for making a WYSIWYG editor that works in the browser.

--- a/src/ngx-wig.component.ts
+++ b/src/ngx-wig.component.ts
@@ -142,7 +142,6 @@ export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor 
 
   public shouldShowPlaceholder(): boolean {
     return this.placeholder
-      && !this.hasFocus
       && !this.container.innerText;
   }
 

--- a/src/ngx-wig.component.ts
+++ b/src/ngx-wig.component.ts
@@ -1,15 +1,15 @@
 import {
   Component,
   ElementRef,
+  EventEmitter,
   Input,
-  OnInit,
   OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
   ViewEncapsulation,
   forwardRef,
-  SimpleChanges,
-  Output,
-  ViewChild,
-  EventEmitter
 } from '@angular/core';
 
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
@@ -30,6 +30,7 @@ import { NgxWigToolbarService, TButton } from './ngx-wig-toolbar.service';
   encapsulation: ViewEncapsulation.None
 })
 export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor {
+
   @Input()
   public content: string;
 
@@ -99,16 +100,10 @@ export class NgxWigComponent implements OnInit, OnChanges, ControlValueAccessor 
   public ngOnInit(): void {
     this.toolbarButtons = this._ngWigToolbarService.getToolbarButtons(this.buttons);
     this.container = this.ngxWigEditable.nativeElement;
+
     if (this.content) {
       this.container.innerHTML = this.content;
     }
-
-    // view --> model
-    ('keyup change'.split(' ')).forEach(event =>
-      this.container.addEventListener(event, () => {
-        this._onContentChange(this.container.innerHTML);
-      }, false)
-    );
   }
 
   private _onContentChange(newContent: string): void {

--- a/src/ngx-wig.css
+++ b/src/ngx-wig.css
@@ -74,12 +74,14 @@
     */
 
 .nw-editor {
-  display: table;
   /* Default when height is not set */
+  display: block;
+  position: relative;
   height: 300px;
   background: #fff;
   cursor: text;
   width: 100%;
+  overflow-y: auto;
 }
 
 .nw-editor-container {
@@ -93,15 +95,16 @@
 }
 
 .nw-editor__res {
+  display: block;
   min-height: 100%;
-  padding: 0 8px;
-  display: table-cell;
+  padding: 1px 8px;
 }
 
 .nw-editor__placeholder {
+  display: block;
+  position: absolute;
   padding: 1px 8px;
   color: lightgray;
-  display: table-cell;
   width: 100%;
 }
 
@@ -129,7 +132,7 @@
 .nw-editor__src {
   height: 100%;
   resize: none;
-  padding: 0 8px;
+  padding: 1px 8px;
 }
 
 .nw-editor--fixed .nw-editor {

--- a/src/ngx-wig.html
+++ b/src/ngx-wig.html
@@ -1,7 +1,8 @@
 <div class="ng-wig">
-  <ul class="nw-toolbar"
-      *ngIf="toolbarButtons.length">
-    <li class="nw-toolbar__item" *ngFor="let button of toolbarButtons">
+  <ul *ngIf="toolbarButtons.length"
+      class="nw-toolbar">
+    <li *ngFor="let button of toolbarButtons"
+        class="nw-toolbar__item">
       <div *ngIf="!button.isComplex">
         <button type="button"
                 class="nw-button"
@@ -32,8 +33,8 @@
   <div class="nw-editor-container"
        (click)="container.focus()"
        [ngClass]="{ 'nw-editor-container--with-toolbar': toolbarButtons.length }">
-    <div class="nw-editor__src-container"
-         *ngIf="editMode">
+    <div *ngIf="editMode"
+         class="nw-editor__src-container">
       <textarea [ngModel]="content"
                 (ngModelChange)="onTextareaChange($event)"
                 (blur)="propagateTouched()"
@@ -41,10 +42,10 @@
       </textarea>
     </div>
     <div class="nw-editor"
-         [ngClass]="{ 'nw-disabled': disabled,'nw-invisible': editMode}">
-      <div class="nw-editor__placeholder"
-           [innerText]="placeholder"
-           *ngIf="shouldShowPlaceholder()">
+         [ngClass]="{ 'nw-disabled': disabled,'nw-invisible': editMode }">
+      <div *ngIf="shouldShowPlaceholder()"
+           class="nw-editor__placeholder"
+           [innerText]="placeholder">
       </div>
       <div #ngWigEditable
            class="nw-editor__res"

--- a/src/ngx-wig.html
+++ b/src/ngx-wig.html
@@ -52,7 +52,8 @@
            [attr.contenteditable]="!disabled"
            [ngClass]="{ disabled: disabled}"
            (focus)="hasFocus = true"
-           (blur)="onBlur()"><!--
+           (blur)="onBlur()"
+           (input)="_onContentChange(ngWigEditable.innerHTML)"><!--
   --></div>
     </div>
   </div>


### PR DESCRIPTION
- styles refactoring
- use `(input)` instead of two listeners
- placeholder fix
- add scroll when content is too long

![out-34](https://user-images.githubusercontent.com/14031187/38676564-12fa444a-3e64-11e8-8a56-eded8f514cdf.gif)
