### PR TITLE
The content of the editor is not updated when using Promises

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -149,6 +149,10 @@ export class NgxWigComponent implements AfterViewInit,
 
   public ngOnChanges(changes: SimpleChanges): void {
     if (this.container && changes['content']) {
+
+      // we need to focus the container before pasting at the caret
+      this.container.focus();
+
       // clear the previous content
       this.container.innerHTML = '';
 
@@ -180,7 +184,6 @@ export class NgxWigComponent implements AfterViewInit,
 
     if (window.getSelection) {
       sel = window.getSelection();
-
       if (sel.getRangeAt && sel.rangeCount) {
         range = sel.getRangeAt(0);
         range.deleteContents();


### PR DESCRIPTION
When we are trying to update the value of the `@Input` `content` property from a `Promise` based source, the value is updated in the model but not in the view.

The problem is related with the `pasteHtmlAtCaret` method and specifically when it checks for a valid `Selection` object:

```
sel = window.getSelection();
if (sel.getRangeAt && sel.rangeCount) {
}
```

The check in the `if` statement fails because there is no valid selection, that is the editor is not focused. We need to call the `focus` method on the `container` before allowing the `pasteHtmlAtCaret` to be executed,

This PR adds the necessary focus method in the `ngOnChanges` method of the component.

