### PR TITLE
Fix issue: cannot enter HTML-tags manually in IE11 while "Edit HTML" mode is activated

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -125,7 +125,9 @@ export class NgxWigComponent implements AfterViewInit,
     // check if the browser is IE:
     if (window.document['documentMode']) {
       this._mutationObserver = new MutationObserver(() => {
-        this.onContentChange(this.container.innerHTML);
+        if (!this.editMode) {
+          this.onContentChange(this.container.innerHTML);
+        }
       });
 
       this._mutationObserver.observe(


### PR DESCRIPTION
Cannot enter HTML-tags manually in IE11 while "Edit HTML" mode is activated. The editor replaces specific characters ("<", ">") when user tries to enter them via keyboard.

Steps for reprodusing:
1. Open the widget using IE11
2. Click on "Edit HTML" button
3. Try to enter "<" or ">" via keyboard (without copy-paste).

Actual Result:
Characters are replaced by HTML entities (`"<" -> "&lt;"` and `">" -> "&gt;"`). After switching to common mode, user sees "<" and ">" characters instead of template with correct formatting (`<b>test</b>` instead of **test**).

Edit HTML-mode:
![Screenshot from 2020-09-17 15-15-05](https://user-images.githubusercontent.com/10753900/93469071-a27e8580-f8f8-11ea-99d8-d8819609c0ff.png)

Common mode:
![image](https://user-images.githubusercontent.com/10753900/93469139-bcb86380-f8f8-11ea-99ac-7eebbebec155.png)



-----

Technical details:

When editMode is activated in IE11, it works next way:
1. The textarea calls onTextareaChange what changes innerHTML of contenteditable node
2. The MutationObserver triggers onContentChange what replaces current textarea value by innerHTML of contenteditable node

The problem happens because the field innerHTML replaces some characters if current HTML is invalid.
```
"foo<"          => "foo&lt;"
"foo<b>"        => "foo<b></b>"
"foo<b>bar</b>" => "foo<b>bar</b>"
```

---

As a solution, I suggest to ignore mutation effects of contenteditable for IE11 while "Edit HTML" mode is activated. The changes will be handled by onTextareaChange anyway, so seems to me everything should work fine.

---

Related commit: https://github.com/stevermeister/ngx-wig/pull/89