### PR TITLE
Fix <br> tag instead of empty string issue

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
@@ -256,6 +256,14 @@ describe('NgxWigComponent', () => {
       expect(spy.calls.first().args[0]).toBe(newContent);
     });
 
+    it('should emit empty string if content innerText is empty', () => {
+      const newContent = '<br>';
+      const spy = spyOn(component.contentChange, 'emit');
+      component.onContentChange(newContent);
+      expect(component.content).toBe('');
+      expect(spy.calls.first().args[0]).toBe('');
+    });
+
     it('should change the content (onTextareaChange)', () => {
       const newText = '<p>New fake text</p>';
       const spy = spyOn(component, 'onContentChange');

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -35,9 +35,9 @@ import { TButton, commandFunction } from './config';
   encapsulation: ViewEncapsulation.None
 })
 export class NgxWigComponent implements OnInit,
-                                        OnChanges,
-                                        OnDestroy,
-                                        ControlValueAccessor {
+  OnChanges,
+  OnDestroy,
+  ControlValueAccessor {
 
   @Input()
   public content: string;
@@ -122,7 +122,8 @@ export class NgxWigComponent implements OnInit,
   }
 
   public onContentChange(newContent: string): void {
-    this.content = newContent;
+    this.content = this.isInnerTextEmpty(newContent) ? '' : newContent;
+
     this.contentChange.emit(this.content);
     this.propagateChange(this.content);
   }
@@ -210,5 +211,12 @@ export class NgxWigComponent implements OnInit,
 
   setDisabledState(isDisabled: boolean): void {
     this.disabled = isDisabled;
+  }
+
+  isInnerTextEmpty(content: string): boolean {
+    const parser = new DOMParser();
+    const htmlDoc = parser.parseFromString(content, 'text/html');
+
+    return htmlDoc.documentElement?.innerText === '';
   }
 }


### PR DESCRIPTION
#### Description
Added check for newContent string before emitting. If the `innerText` of resulting html element is empty, emits empty string instead of empty tags

Fix for #168 