### PR TITLE
Restored default NG ViewEncapsulation to prevent poluting css namespace

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -8,7 +8,6 @@ import {
   Output,
   SimpleChanges,
   ViewChild,
-  ViewEncapsulation,
   forwardRef,
   Inject,
   OnDestroy,

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -31,8 +31,7 @@ import { TButton, commandFunction } from './config';
       useExisting: forwardRef(() => NgxWigComponent),
       multi: true
     }
-  ],
-  encapsulation: ViewEncapsulation.None
+  ]
 })
 export class NgxWigComponent implements OnInit,
   OnChanges,


### PR DESCRIPTION
This is to allow using ngx-wig without poluting the CSS namespace.

We are using ngx-wig together with [bulma dropdown](https://bulma.io/documentation/components/dropdown/) and `droprown` and `dropdown-content` classes are available in both.

I am branching `v13.1.6` because we use angular 13, so would appreciate if a 13.x version gets published in the end as well.