### PR TITLE
Fix: Form Control and `content` not reflecting any changes when pasting text

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -167,6 +167,8 @@ export class NgxWigComponent
     } else {
       this.pasteHtmlAtCaret(text);
     }
+
+    this.onContentChange(this.container.innerHTML)
   }
 
   public onTextareaChange(newContent: string): void {

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -168,7 +168,7 @@ export class NgxWigComponent
       this.pasteHtmlAtCaret(text);
     }
 
-    this.onContentChange(this.container.innerHTML)
+    this.onContentChange(this.container.innerHTML);
   }
 
   public onTextareaChange(newContent: string): void {


### PR DESCRIPTION
I have fixed an issue where pasting text inside the editor's text box would not update the form control value or cause `contentChange` to emit a value.

The issue seems to stem from the fact that anytime a paste event happens, we call `event.preventDefault`, and then we modify the html nodes, which causes zone.js to not pick up any of the added changes, until we actually manually add more content by typing into the text box.

Take a look at the issue for more info #211.