### PR TITLE
Add `unlink` functionality

### DIFF
--- a/projects/ngx-wig/src/lib/config.ts
+++ b/projects/ngx-wig/src/lib/config.ts
@@ -49,7 +49,7 @@ export const DEFAULT_LIBRARY_BUTTONS: TButtonLibrary = {
   },
   link: {
     label: 'Link',
-    title: 'Link',
+    title: 'Add or remove link',
     command: 'createlink',
     styleClass: 'nw-link',
     icon: 'nwe-icon-link'

--- a/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
@@ -215,6 +215,58 @@ describe('NgxWigComponent', () => {
       });
     });
 
+    describe('isLinkSelected method', () => {
+      function mockGetSelection(
+        selectionText: string,
+        selection: Partial<Selection> | null = null
+      ) {
+        spyOn(window, 'getSelection').and.returnValue({
+          toString: () => selectionText,
+          ...selection,
+        } as Selection);
+      }
+    
+      it('should return false if there is no selection', () => {
+        mockGetSelection('');
+        expect(component.isLinkSelected()).toBe(false);
+      });
+    
+      it('should return false if the selection is not within a link', () => {
+        const selection = {
+          focusNode: { parentNode: { nodeName: 'SPAN' } },
+          anchorNode: { parentNode: { nodeName: 'SPAN' } },
+        } as Partial<Selection>;
+        mockGetSelection('text', selection);
+    
+        expect(component.isLinkSelected()).toBe(false);
+      });
+    
+      it('should return true if the focusNode is within a link', () => {
+        const selection = {
+          focusNode: { parentNode: { nodeName: 'A' } },
+          anchorNode: { parentNode: { nodeName: 'SPAN' } },
+        } as Partial<Selection>;
+        mockGetSelection('text', selection);
+    
+        expect(component.isLinkSelected()).toBe(true);
+      });
+    
+      it('should return true if the anchorNode is within a link', () => {
+        const selection = {
+          focusNode: { parentNode: { nodeName: 'DIV' } },
+          anchorNode: { parentNode: { nodeName: 'A' } },
+        } as Partial<Selection>;
+        mockGetSelection('text', selection);
+    
+        expect(component.isLinkSelected()).toBe(true);
+      });
+    
+      it('should return false if selection is null', () => {
+        mockGetSelection('text', null);
+        expect(component.isLinkSelected()).toBe(false);
+      });
+    }); 
+
     describe('execCommand', () => {
       it('should call execCommand', () => {
         const spy = spyOn(component, 'execCommand');
@@ -264,6 +316,18 @@ describe('NgxWigComponent', () => {
         expect(page.promptSpy.calls.any()).toBe(false);
       });
 
+      it('should not show a prompt when the command is createlink and selected text contains a link', () => {
+        spyOn(component, 'isLinkSelected').and.returnValue(true)
+        component.execCommand('createlink', '');
+        expect(page.promptSpy.calls.any()).toBe(false);
+      });
+
+      it('should execute unlink command', () => {
+        spyOn(component, 'isLinkSelected').and.returnValue(true)
+        component.execCommand('createlink', '');
+        expect(page.execCommandSpy).toHaveBeenCalledWith('unlink', false);
+      });
+      
       it('should return if the prompt is cancelled', () => {
         page.promptSpy.and.returnValue(undefined);
         component.execCommand('createlink', '');


### PR DESCRIPTION
This PR introduces the `unlink` functionality. Currently, users are unable to unlink text once it has been linked. If a user selects linked text and presses the create-link button, a prompt is shown instead of unlinking the text (expected behavior). This requires users to manually remove the link by deleting the text and re-adding it, which is not user-friendly.

With this update, users can now easily unlink text by selecting the linked text and pressing the link button, which will remove the link without the need for manual text removal.

#### Changes
 - Added the `isLinkSelected` method to identify if the selected text contains an anchor tag.
 - Updated the link button behavior to remove links when pressed on already linked text.
 - Updated the button title to “Add or remove link” to reflect its dual functionality.

#### Testing
 - Verified that pressing the link button on linked text now execute the "unlink" command.
 - Ensured that the prompt is only shown when linking new text.
 - Verified the behavior of the `isLinkSelected` method in different scenarios.
 
#### Notes
This enhancement improves the user experience by providing a straightforward way to unlink text, aligning with common text editor functionalities.