### PR TITLE
Fix: Use carat version range for angular dependencies

### DIFF
--- a/projects/ngx-wig/package.json
+++ b/projects/ngx-wig/package.json
@@ -14,9 +14,9 @@
   },
   "homepage": "https://github.com/stevermeister/ngx-wig",
   "peerDependencies": {
-    "@angular/common": "19.0.5",
-    "@angular/core": "19.0.5",
-    "@angular/forms": "19.0.5"
+    "@angular/common": "^19.0.5",
+    "@angular/core": "^19.0.5",
+    "@angular/forms": "^19.0.5"
   },
   "dependencies": {
     "tslib": "^2.2.0"


### PR DESCRIPTION
I believe I made a mistake in my original PR and removed the version range symbol from the angular package dependencies in `package.json`; as a result anyone who wants to update to Angualr 19.1.0, will be met with an error. 😟

My bad. Sorry.

Would appreciate if you could merge and release this @stevermeister.