### PR TITLE
Fix overlapping dropdowns in toolbar

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig-component.css
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.css
@@ -317,14 +317,16 @@ div.select-menu>select {
   z-index: 1;
 }
 
-.nwe-dropdown-content a {
+.nwe-dropdown-content button {
   color: black;
   padding: 10px 10px;
   text-decoration: none;
   display: inline-flex;
   width: fit-content;
+  background: none;
+  border: none;
 }
 
-.nwe-dropdown a:hover {background-color: #ddd;}
+.nwe-dropdown button:hover {background-color: #ddd;}
 
 .nwe-show {display: block;}

--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -19,9 +19,9 @@
         </div>
         <ng-template #selectMenu>
           <div class="nwe-dropdown"
-                (mouseenter)="button.isOpenOnMouseOver?button.visibleDropdown = true:true"
-                (mouseleave)="button.isOpenOnMouseOver?button.visibleDropdown = false:true"
-                (click)="!button.isOpenOnMouseOver?button.visibleDropdown = !button.visibleDropdown:true">
+                (mouseenter)="button.isOpenOnMouseOver ? button.visibleDropdown = true : null"
+                (mouseleave)="button.isOpenOnMouseOver ? button.visibleDropdown = false : null"
+                (click)="toggleDropdown(button)">
             <button type="button"
                   class="nw-button"
                   [ngClass]="[button.styleClass]"
@@ -36,22 +36,20 @@
             </button>
             <div class="nwe-dropdown-content"
                   [ngClass]="button.visibleDropdown ? 'nwe-show' : ''">
-              <a *ngFor="let child of button.children"
-                    href="#">
-                <button type="button"
+              <button *ngFor="let child of button.children"
+                      type="button"
                       class="nw-button"
                       [ngClass]="[child.styleClass]"
                       [title]="child.title"
-                      (click)="execCommand(child.command)"
+                      (click)="execCommand(child.command); button.visibleDropdown = false"
                       [disabled]="disabled"
                       tabindex="-1">
-                  <ng-container *ngIf="!child.icon">{{ child.label }}</ng-container>
-                  <div *ngIf="child.icon"
-                        class="nwe-icon"
-                        [ngClass]="[child.icon]">
-                  </div>
-                </button>
-              </a>
+                <ng-container *ngIf="!child.icon">{{ child.label }}</ng-container>
+                <div *ngIf="child.icon"
+                      class="nwe-icon"
+                      [ngClass]="[child.icon]">
+                </div>
+              </button>
             </div>
           </div>
         </ng-template>

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -143,6 +143,20 @@ export class NgxWigComponent
     }
   }
 
+  public toggleDropdown(button: TButton): void {
+    if (button.isOpenOnMouseOver) {
+      return;
+    }
+
+    const newState = !button.visibleDropdown;
+    this.toolbarButtons.forEach(b => {
+      if (b !== button) {
+        b.visibleDropdown = false;
+      }
+    });
+    button.visibleDropdown = newState;
+  }
+
   public ngOnDestroy(): void {
     if (this._mutationObserver) {
       this._mutationObserver.disconnect();


### PR DESCRIPTION
## Summary
- avoid anchors in dropdown items
- update dropdown styles for button items
- close other dropdowns when toggling

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685196d980f08324a4c1dcd6803da9fc