### PR TITLE
feat: improve toolbar accessibility

### DIFF
--- a/projects/ngx-wig/src/lib/config.ts
+++ b/projects/ngx-wig/src/lib/config.ts
@@ -7,6 +7,7 @@ export interface TButton {
   label?: string;
   icon?: string;
   title?: string;
+  ariaLabel?: string;
   children?: TButton[];
   command?: string | CommandFunction;
   styleClass?: string;

--- a/projects/ngx-wig/src/lib/config.ts
+++ b/projects/ngx-wig/src/lib/config.ts
@@ -13,6 +13,11 @@ export interface TButton {
   styleClass?: string;
   visibleDropdown?: boolean;
   isOpenOnMouseOver?: boolean;
+  /**
+   * Tracks the currently focusable child button when the toolbar button has a dropdown.
+   * Implements a roving tabindex pattern for dropdown items.
+   */
+  dropdownButtonIndex?: number;
 }
 
 export interface TButtonLibrary {

--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -32,17 +32,18 @@
           class="nwe-dropdown-content"
           [ngClass]="button.visibleDropdown ? 'nwe-show' : ''"
         >
-          @for (child of button.children; track child) {
+          @for (child of button.children; let j = $index; track child) {
           <a href="#">
             <button
               type="button"
               class="nw-button"
               [ngClass]="[child.styleClass]"
               [title]="child.title"
-              (click)="execCommand(child.command)"
+              (click)="execCommand(child.command); closeDropdown(button)"
               [disabled]="disabled"
-              tabindex="-1"
-              (keydown)="onDropdownKeydown($event)"
+              [attr.tabindex]="button.visibleDropdown && button.dropdownButtonIndex === j ? 0 : -1"
+              (focus)="button.dropdownButtonIndex = j"
+              (keydown)="onDropdownKeydown($event, button)"
               [attr.aria-label]="child.ariaLabel || child.title || child.label"
             >
               @if (child.icon) {

--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -1,6 +1,6 @@
 <div class="ng-wig">
   <ul class="nw-toolbar">
-    @for (button of toolbarButtons; track button) {
+    @for (button of toolbarButtons; let i = $index; track button) {
     <li class="nw-toolbar__item">
       @if (button.children) {
       <div
@@ -11,15 +11,19 @@
         (keydown.enter)="onDropdownButtonSelected(button, $event)"
       >
         <button
+          #toolbarButton
           type="button"
           class="nw-button"
           [ngClass]="[button.styleClass]"
           [title]="button.title"
           [disabled]="disabled"
-          tabindex="-1"
+          [attr.tabindex]="toolbarButtonIndex === i ? 0 : -1"
+          (focus)="toolbarButtonIndex = i"
+          (keydown)="onToolbarKeydown($event, i)"
+          [attr.aria-label]="button.ariaLabel || button.title || button.label"
         >
           @if (button.icon) {
-          <div class="nwe-icon" [ngClass]="[button.icon]"></div>
+          <div class="nwe-icon" [ngClass]="[button.icon]" aria-hidden="true" [attr.focusable]="false"></div>
           } @else {<!--
              -->{{ button.label }}<!--
           -->}
@@ -38,9 +42,10 @@
               (click)="execCommand(child.command)"
               [disabled]="disabled"
               tabindex="-1"
+              [attr.aria-label]="child.ariaLabel || child.title || child.label"
             >
               @if (child.icon) {
-              <div class="nwe-icon" [ngClass]="[child.icon]"></div>
+              <div class="nwe-icon" [ngClass]="[child.icon]" aria-hidden="true" [attr.focusable]="false"></div>
               } @else {<!--
                 -->{{ child.label }}<!--
               -->}
@@ -52,16 +57,20 @@
       } @else {
       <div>
         <button
+          #toolbarButton
           type="button"
           class="nw-button"
           [ngClass]="[button.styleClass]"
           [title]="button.title"
           (click)="execCommand(button.command)"
           [disabled]="disabled"
-          tabindex="-1"
+          [attr.tabindex]="toolbarButtonIndex === i ? 0 : -1"
+          (focus)="toolbarButtonIndex = i"
+          (keydown)="onToolbarKeydown($event, i)"
+          [attr.aria-label]="button.ariaLabel || button.title || button.label"
         >
           @if (button.icon) {
-          <div class="nwe-icon" [ngClass]="[button.icon]"></div>
+          <div class="nwe-icon" [ngClass]="[button.icon]" aria-hidden="true" [attr.focusable]="false"></div>
           } @else {<!--
               -->{{ button.label }}<!--
           -->}

--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -7,7 +7,7 @@
         class="nwe-dropdown"
         (mouseenter)="button.isOpenOnMouseOver?button.visibleDropdown = true:true"
         (mouseleave)="button.isOpenOnMouseOver?button.visibleDropdown = false:true"
-        (click)="onDropdownButtonSelected(button)"
+          (click)="onDropdownButtonSelected(button, $event)"
         (keydown.enter)="onDropdownButtonSelected(button, $event)"
       >
         <button
@@ -42,6 +42,7 @@
               (click)="execCommand(child.command)"
               [disabled]="disabled"
               tabindex="-1"
+              (keydown)="onDropdownKeydown($event)"
               [attr.aria-label]="child.ariaLabel || child.title || child.label"
             >
               @if (child.icon) {

--- a/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
@@ -163,6 +163,32 @@ describe('NgxWigComponent', () => {
       expect(document.activeElement).toBe(secondBtn);
     });
 
+    it('should move focus with Tab key and exit at end', () => {
+      const buttons = page.buttons;
+      buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(buttons[1]);
+
+      // move back with shift+Tab
+      buttons[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(buttons[0]);
+
+      // navigate to last button
+      for (let i = 0; i < buttons.length - 1; i++) {
+        buttons[i].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+        fixture.detectChanges();
+      }
+      const lastBtn = buttons[buttons.length - 1];
+      expect(document.activeElement).toBe(lastBtn);
+
+      const tabEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+      const preventSpy = spyOn(tabEvent, 'preventDefault');
+      lastBtn.dispatchEvent(tabEvent);
+      fixture.detectChanges();
+      expect(preventSpy).not.toHaveBeenCalled();
+    });
+
     it('should have an editor container', () => {
       expect(page.editContainerDiv.classList.contains('nw-editor-container--with-toolbar')).toBeDefined();
     });

--- a/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
@@ -140,8 +140,11 @@ describe('NgxWigComponent', () => {
     it('should have a standard button', () => {
       expect(page.unorderedListBtn.classList.contains('nw-list-ul')).toBe(true);
       expect(page.unorderedListBtn.getAttribute('title')).toBe('Unordered List');
-      expect(page.unorderedListBtn.tabIndex).toBe(-1);
+      expect(page.unorderedListBtn.tabIndex).toBe(0);
+      expect(page.unorderedListBtn.getAttribute('aria-label')).toBe('Unordered List');
       expect(page.iconsEl[0].classList.contains('nwe-icon-list-ul')).toBe(true);
+      expect(page.iconsEl[0].getAttribute('aria-hidden')).toBe('true');
+      expect(page.iconsEl[0].getAttribute('focusable')).toBe('false');
     });
 
     it('should have a standard button without icon', () => {
@@ -149,6 +152,15 @@ describe('NgxWigComponent', () => {
       fixture.detectChanges();
       expect(page.unorderedListBtn.textContent).toBe('UL');
       expect(page.iconsEl[0].classList.contains('nwe-icon-list-ul')).toBe(false);
+    });
+
+    it('should move focus with arrow keys', () => {
+      const secondBtn = page.buttons[1];
+      page.unorderedListBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+      fixture.detectChanges();
+      expect(page.unorderedListBtn.tabIndex).toBe(-1);
+      expect(secondBtn.tabIndex).toBe(0);
+      expect(document.activeElement).toBe(secondBtn);
     });
 
     it('should have an editor container', () => {

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -257,19 +257,40 @@ export class NgxWigComponent
   }
 
   public onToolbarKeydown(event: KeyboardEvent, index: number): void {
-    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
-      return;
-    }
-    event.preventDefault();
     const buttons = this.toolbarButtonElems?.toArray();
     if (!buttons || buttons.length === 0) {
       return;
     }
-    if (event.key === 'ArrowRight') {
-      this.toolbarButtonIndex = (index + 1) % buttons.length;
-    } else {
-      this.toolbarButtonIndex = (index - 1 + buttons.length) % buttons.length;
+    const lastIndex = buttons.length - 1;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        event.preventDefault();
+        this.toolbarButtonIndex = (index + 1) % buttons.length;
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        this.toolbarButtonIndex = (index - 1 + buttons.length) % buttons.length;
+        break;
+      case 'Tab':
+        if (event.shiftKey) {
+          if (index === 0) {
+            return;
+          }
+          event.preventDefault();
+          this.toolbarButtonIndex = index - 1;
+        } else {
+          if (index === lastIndex) {
+            return;
+          }
+          event.preventDefault();
+          this.toolbarButtonIndex = index + 1;
+        }
+        break;
+      default:
+        return;
     }
+
     buttons[this.toolbarButtonIndex].nativeElement.focus();
   }
 

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -8,6 +8,8 @@ import {
   Output,
   SimpleChanges,
   ViewChild,
+  ViewChildren,
+  QueryList,
   ViewEncapsulation,
   forwardRef,
   Inject,
@@ -61,8 +63,12 @@ export class NgxWigComponent
   public container: HTMLElement;
   public toolbarButtons: TButton[] = [];
   public hasFocus = false;
+  public toolbarButtonIndex = 0;
 
   private readonly _mutationObserver: MutationObserver;
+
+  @ViewChildren('toolbarButton', { read: ElementRef })
+  private toolbarButtonElems: QueryList<ElementRef>;
 
   public constructor(
     private readonly _ngWigToolbarService: NgxWigToolbarService,
@@ -248,6 +254,23 @@ export class NgxWigComponent
 
     if (button.isOpenOnMouseOver) return;
     button.visibleDropdown = !button.visibleDropdown;
+  }
+
+  public onToolbarKeydown(event: KeyboardEvent, index: number): void {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+      return;
+    }
+    event.preventDefault();
+    const buttons = this.toolbarButtonElems?.toArray();
+    if (!buttons || buttons.length === 0) {
+      return;
+    }
+    if (event.key === 'ArrowRight') {
+      this.toolbarButtonIndex = (index + 1) % buttons.length;
+    } else {
+      this.toolbarButtonIndex = (index - 1 + buttons.length) % buttons.length;
+    }
+    buttons[this.toolbarButtonIndex].nativeElement.focus();
   }
 
   private pasteHtmlAtCaret(html) {

--- a/projects/ngx-wig/src/lib/ngx-wig.component.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.ts
@@ -281,7 +281,7 @@ export class NgxWigComponent
           this.toolbarButtonIndex = index - 1;
         } else {
           if (index === lastIndex) {
-            return;
+            return; // Allow Tab to move focus out of the toolbar
           }
           event.preventDefault();
           this.toolbarButtonIndex = index + 1;


### PR DESCRIPTION
## Summary
- implement roving tabindex for toolbar buttons
- allow custom aria labels and hide decorative icons
- add keyboard navigation test for toolbar

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*
- `npm run lint` *(fails: Could not find the '@angular-eslint/builder:lint' builder's node package)*

------
https://chatgpt.com/codex/tasks/task_b_68a22d77b75c832e98492dfd3e14ef07