### PR TITLE
Enable keyboard navigation for dropdown buttons

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -7,7 +7,7 @@
         class="nwe-dropdown"
         (mouseenter)="button.isOpenOnMouseOver?button.visibleDropdown = true:true"
         (mouseleave)="button.isOpenOnMouseOver?button.visibleDropdown = false:true"
-        (click)="onDropdownButtonSelected(button)"
+          (click)="onDropdownButtonSelected(button, $event)"
         (keydown.enter)="onDropdownButtonSelected(button, $event)"
       >
         <button
@@ -42,6 +42,7 @@
               (click)="execCommand(child.command)"
               [disabled]="disabled"
               tabindex="-1"
+              (keydown)="onDropdownKeydown($event)"
               [attr.aria-label]="child.ariaLabel || child.title || child.label"
             >
               @if (child.icon) {


### PR DESCRIPTION
## Summary
- Import `DOCUMENT` from `@angular/common`
- Add roving tabindex and arrow-key navigation for dropdown child buttons
- Guard toolbar navigation against invalid indices
- Simplify dropdown keyboard navigation without tracking dropdownButtonIndex

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*
- `npm run lint` *(fails: Could not find the '@angular-eslint/builder:lint' builder's node package)*

------
https://chatgpt.com/codex/tasks/task_b_68c10f73569c832ea1a739e7ebfc5aa7