### PR TITLE
feat: improve dropdown keyboard accessibility

### DIFF
--- a/projects/ngx-wig/src/lib/config.ts
+++ b/projects/ngx-wig/src/lib/config.ts
@@ -13,6 +13,11 @@ export interface TButton {
   styleClass?: string;
   visibleDropdown?: boolean;
   isOpenOnMouseOver?: boolean;
+  /**
+   * Tracks the currently focusable child button when the toolbar button has a dropdown.
+   * Implements a roving tabindex pattern for dropdown items.
+   */
+  dropdownButtonIndex?: number;
 }
 
 export interface TButtonLibrary {

--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -32,17 +32,18 @@
           class="nwe-dropdown-content"
           [ngClass]="button.visibleDropdown ? 'nwe-show' : ''"
         >
-          @for (child of button.children; track child) {
+          @for (child of button.children; let j = $index; track child) {
           <a href="#">
             <button
               type="button"
               class="nw-button"
               [ngClass]="[child.styleClass]"
               [title]="child.title"
-              (click)="execCommand(child.command)"
+              (click)="execCommand(child.command); closeDropdown(button)"
               [disabled]="disabled"
-              tabindex="-1"
-              (keydown)="onDropdownKeydown($event)"
+              [attr.tabindex]="button.visibleDropdown && button.dropdownButtonIndex === j ? 0 : -1"
+              (focus)="button.dropdownButtonIndex = j"
+              (keydown)="onDropdownKeydown($event, button)"
               [attr.aria-label]="child.ariaLabel || child.title || child.label"
             >
               @if (child.icon) {


### PR DESCRIPTION
## Summary
- implement roving tabindex for dropdown menu items
- close dropdown with Escape and restore focus to toolbar button
- return focus to parent button whenever a dropdown closes

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*
- `npm run lint` *(fails: Could not find the '@angular-eslint/builder:lint' builder's node package)*
- `CI=true npm run lib-build`


------
https://chatgpt.com/codex/tasks/task_b_68c11cf80140832e9db44fb9148eefad