### PR TITLE
feat(a11y): add accessibility attributes to editable div

### DIFF
--- a/projects/ngx-wig/src/lib/ngx-wig-component.html
+++ b/projects/ngx-wig/src/lib/ngx-wig-component.html
@@ -110,6 +110,8 @@
       <div
         #ngWigEditable
         class="nw-editor__res"
+        role="textbox"
+        aria-multiline="true"
         [attr.contenteditable]="!disabled"
         [ngClass]="{ disabled: disabled}"
         (paste)="onPaste($event)"

--- a/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
+++ b/projects/ngx-wig/src/lib/ngx-wig.component.spec.ts
@@ -213,6 +213,16 @@ describe('NgxWigComponent', () => {
       expect(page.placeholderEl.innerText).toBe('Insert text here');
     });
 
+    describe('accessibility attributes', () => {
+      it('should have role="textbox" on the editable div', () => {
+        expect(page.editableDiv.getAttribute('role')).toBe('textbox');
+      });
+
+      it('should have aria-multiline="true" on the editable div', () => {
+        expect(page.editableDiv.getAttribute('aria-multiline')).toBe('true');
+      });
+    });
+
     describe('focus', () => {
       it('when container click', () => {
         page.editContainerDiv.click();


### PR DESCRIPTION
## Description

This PR adds accessibility attributes to the ngx-wig rich text editor's contenteditable div to improve screen reader support.

### Changes

The contenteditable div now includes:
- `role="textbox"` - Identifies the element as a text input for assistive technologies
- `aria-multiline="true"` - Indicates this is a multiline text input

These attributes ensure that screen readers and other assistive technologies can properly identify the rich text editor as an input field, which is required for WCAG compliance.

### Testing

Added unit tests to verify:
- The editable div has `role="textbox"` attribute
- The editable div has `aria-multiline="true"` attribute
