### PR TITLE
fix(demo): correct bold/italic icon class names

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,14 +11,14 @@ export const DEFAULT_LIBRARY_BUTTONS = {
     title: 'Bold',
     command: 'bold',
     styleClass: 'bold',
-    icon: 'icon-bold'
+    icon: 'nwe-icon-bold'
   },
   italic: {
     label: 'I',
     title: 'Italic',
     command: 'italic',
     styleClass: 'italic',
-    icon: 'icon-italic'
+    icon: 'nwe-icon-italic'
   },
   fontName: {
     label: 'F',


### PR DESCRIPTION
## What

The demo app's bold and italic toolbar buttons render with no icon. This fixes the two icon class names so both buttons show their glyphs.

## Why

The demo passes a custom `buttonsConfig` to `NgxWigModule.forRoot(...)` that overrides the default `bold`/`italic` buttons with the wrong icon classes:

```ts
bold:   { ..., icon: 'icon-bold' }
italic: { ..., icon: 'icon-italic' }
```

The library CSS only defines the `nwe-`-prefixed classes (`.nwe-icon-bold`, `.nwe-icon-italic`). With no matching rule, the background SVG never loads, so the buttons render blank. The other buttons (UL, OL, link, underline) use the library defaults with correct classes, which is why only bold/italic were affected.

The classes were renamed `icon-*` → `nwe-icon-*` in 1cc0c67, but this demo override was never updated — so it's been broken on `master` ever since (independent of the Angular 22 upgrade).

## Fix

```diff
-    icon: 'icon-bold'
+    icon: 'nwe-icon-bold'
...
-    icon: 'icon-italic'
+    icon: 'nwe-icon-italic'
```

## Verification

Built the lib + ran the demo locally — both **B** and **I** icons now render correctly alongside the rest of the toolbar.

Reported by @bampakoa in #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
